### PR TITLE
[WIP] Request uri params

### DIFF
--- a/contao/assets/jquery.ajax-reload-form.js
+++ b/contao/assets/jquery.ajax-reload-form.js
@@ -30,7 +30,7 @@
 					action: 'reload-element',
 					element: element.attr('data-ajax-reload-element'),
 					auto_item: (typeof element.attr('data-ajax-reload-auto-item') != typeof undefined) ? element.attr('data-ajax-reload-auto-item') : '',
-					requestUri: params['requestUri'],
+					requestUri: decodeURIComponent(params['requestUri']),
 					page: options.page,
 					REQUEST_TOKEN: form.find('[name=REQUEST_TOKEN]').val()
 				}),

--- a/contao/assets/jquery.ajax-reload-form.js
+++ b/contao/assets/jquery.ajax-reload-form.js
@@ -21,12 +21,16 @@
 			var element = $(this).closest('[class^="ce_"],[class^="mod_"]');
 			element.addClass(options.reloadCssClass);
 
+            var params = {};
+            form.attr('action').replace(/[?&]+([^=&]+)=([^&]*)/gi,function(s,k,v){params[k]=v});
+
 			$.ajax({
 				method: 'POST',
 				url: 'SimpleAjaxFrontend.php?' + jQuery.param({
 					action: 'reload-element',
 					element: element.attr('data-ajax-reload-element'),
 					auto_item: (typeof element.attr('data-ajax-reload-auto-item') != typeof undefined) ? element.attr('data-ajax-reload-auto-item') : '',
+					requestUri: params['requestUri'],
 					page: options.page,
 					REQUEST_TOKEN: form.find('[name=REQUEST_TOKEN]').val()
 				}),

--- a/contao/classes/AjaxReloadElement.php
+++ b/contao/classes/AjaxReloadElement.php
@@ -68,6 +68,7 @@ class AjaxReloadElement extends \Controller
 	 * * element: "ce::id" or "mod::id" (replace 'id' with the element's id)
 	 * * page: "id" (optionally, replace 'id' with the current page's id)
 	 * * auto_item: (an optional auto_item which will be set before fetching the element)
+     * * requestUri: (optionally uri to fetch the query params from)
 	 */
 	public function getModuleOrContentElement()
 	{
@@ -106,6 +107,13 @@ class AjaxReloadElement extends \Controller
 		if (($strAutoItem = Input::get('auto_item')))
 		{
 			Input::setGet('auto_item', $strAutoItem);
+		}
+
+        list(, $query) = explode('?', Input::get('requestUri', true), 2);
+		parse_str($query, $params);
+
+        foreach ($params as $k => $v) {
+		    Input::setGet($k, $v);
 		}
 
 		switch ($strElementType)

--- a/contao/classes/AjaxReloadElement.php
+++ b/contao/classes/AjaxReloadElement.php
@@ -110,7 +110,8 @@ class AjaxReloadElement extends \Controller
 		}
 
 		// Use the given requestUri param and set its query params (get params)
-        list(, $query) = explode('?', Input::get('requestUri', true), 2);
+        $requestUri = urldecode(Input::get('requestUri', true));
+        list(, $query) = explode('?', $requestUri, 2);
 		parse_str($query, $params);
 
         foreach ($params as $k => $v) {

--- a/contao/classes/AjaxReloadElement.php
+++ b/contao/classes/AjaxReloadElement.php
@@ -109,6 +109,7 @@ class AjaxReloadElement extends \Controller
 			Input::setGet('auto_item', $strAutoItem);
 		}
 
+		// Use the given requestUri param and set its query params (get params)
         list(, $query) = explode('?', Input::get('requestUri', true), 2);
 		parse_str($query, $params);
 

--- a/contao/classes/AjaxReloadElement.php
+++ b/contao/classes/AjaxReloadElement.php
@@ -114,9 +114,16 @@ class AjaxReloadElement extends \Controller
         list(, $query) = explode('?', $requestUri, 2);
 		parse_str($query, $params);
 
+		parse_str(\Environment::get('queryString'), $params2);
+		$params3 = array_merge($params, $params2);
+
         foreach ($params as $k => $v) {
 		    Input::setGet($k, $v);
 		}
+
+		if (null !== $objPage) {
+            \Environment::set('request', $objPage->getFrontendUrl('?'.http_build_query($params3)));
+        }
 
 		switch ($strElementType)
 		{


### PR DESCRIPTION
When using this extension I've had troubles using the MetaModels FE editing - or simply: with elements that use query parameters in the url like `.../editing.html?act=edit&id=foo`.
So I needed to omit the query params. Problems: I cannot use the `_SERVER['HTTP_REFERER']`.
Quickfix works and needs to be optimized.