### PR TITLE
set layout and theme properties

### DIFF
--- a/src/EventListener/AjaxReloadElementListener.php
+++ b/src/EventListener/AjaxReloadElementListener.php
@@ -108,6 +108,9 @@ class AjaxReloadElementListener
         $requestUrl->unsetQueryParameter('ajax_reload_element');
         Environment::set('request', $requestUrl->getUrl());
 
+        // Unset the get parameter (as it manipulates MetaModels filter url)
+        Input::setGet('ajax_reload_element', null);
+
         switch ($elementType) {
             case self::TYPE_MODULE:
                 $element       = ModuleModel::findByPk($elementId);

--- a/src/EventListener/AjaxReloadElementListener.php
+++ b/src/EventListener/AjaxReloadElementListener.php
@@ -138,12 +138,12 @@ class AjaxReloadElementListener
         // Set theme and layout related information in the page object (see #10)
         $theme = $layout->getRelated('pid');
         $this->pictureFactory->setDefaultDensities($theme->defaultImageDensities);
-		$page->layoutId = $layout->id;
-		$page->template = $layout->template ?: 'fe_page';
-		$page->templateGroup = $theme->templates;
-		list($strFormat, $strVariant) = explode('_', $layout->doctype);
-		$page->outputFormat = $strFormat;
-		$page->outputVariant = $strVariant;
+        $page->layoutId = $layout->id;
+        $page->template = $layout->template ?: 'fe_page';
+        $page->templateGroup = $theme->templates;
+        list($strFormat, $strVariant) = explode('_', $layout->doctype);
+        $page->outputFormat = $strFormat;
+        $page->outputVariant = $strVariant;
 
         // Parse the element
         $return = $elementParser($element);

--- a/src/Resources/config/listeners.yml
+++ b/src/Resources/config/listeners.yml
@@ -1,9 +1,4 @@
 services:
-  richardhj.contao_ajax_reload_element.parse_template_listener:
-    class: Richardhj\ContaoAjaxReloadElementBundle\EventListener\AjaxReloadElementListener
-    tags:
-      - { name: 'contao.hook', hook: 'parseTemplate', method: 'onParseTemplate' }
-  richardhj.contao_ajax_reload_element.get_page_layout_listener:
-    class: Richardhj\ContaoAjaxReloadElementBundle\EventListener\AjaxReloadElementListener
-    tags:
-      - { name: 'contao.hook', hook: 'getPageLayout', method: 'onGetPageLayout' }
+  Richardhj\ContaoAjaxReloadElementBundle\EventListener\AjaxReloadElementListener:
+    arguments:
+      - '@contao.image.picture_factory'

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -11,11 +11,12 @@
  * @license   https://github.com/richardhj/contao-ajax_reload_element/blob/master/LICENSE LGPL-3.0
  */
 
+use Richardhj\ContaoAjaxReloadElementBundle\EventListener\AjaxReloadElementListener;
 
 /**
  * Hooks
  *
  * Waiting for Contao 4.5 (see contao/core-bundle#1094) to get rid of this file
  */
-$GLOBALS['TL_HOOKS']['parseTemplate'][] = ['richardhj.contao_ajax_reload_element.parse_template_listener', 'onParseTemplate'];
-$GLOBALS['TL_HOOKS']['getPageLayout'][] = ['richardhj.contao_ajax_reload_element.get_page_layout_listener', 'onGetPageLayout'];
+$GLOBALS['TL_HOOKS']['parseTemplate'][] = [AjaxReloadElementListener::class, 'onParseTemplate'];
+$GLOBALS['TL_HOOKS']['getPageLayout'][] = [AjaxReloadElementListener::class, 'onGetPageLayout'];


### PR DESCRIPTION
Fix for #10 

This PR sets the theme and layout related information for the page object which is needed to correctly render elements.

I also removed the service tags, because I think otherwise the hooks would be executed two times actually in Contao 4.5+?

I also changed the service definition to the FQCN, as recommended now.

But all these changes can be reverted of course, if you don't like them ;)

