### PR TITLE
make service public

### DIFF
--- a/src/Resources/config/listeners.yml
+++ b/src/Resources/config/listeners.yml
@@ -1,4 +1,5 @@
 services:
   Richardhj\ContaoAjaxReloadElementBundle\EventListener\AjaxReloadElementListener:
+    public: true
     arguments:
       - '@contao.image.picture_factory'


### PR DESCRIPTION
Small oversight in my last PR: the service needs to be set to public manually, when not using the service tags. Otherwise you get the following error with Symfony >=4:
```
The "Richardhj\ContaoAjaxReloadElementBundle\EventListener\AjaxReloadElementListener" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.
```