### PR TITLE
Do not use m12 on checkboxes

### DIFF
--- a/src/Resources/contao/dca/tl_article.php
+++ b/src/Resources/contao/dca/tl_article.php
@@ -24,7 +24,7 @@ $GLOBALS['TL_DCA']['tl_article']['fields']['allowAjaxReload'] = [
     'label'     => &$GLOBALS['TL_LANG']['tl_article']['allowAjaxReload'],
     'inputType' => 'checkbox',
     'eval'      => [
-        'tl_class' => 'clr w50 m12',
+        'tl_class' => 'clr w50',
     ],
     'sql'       => "char(1) NOT NULL default ''",
 ];

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -34,7 +34,7 @@ $GLOBALS['TL_DCA']['tl_content']['fields']['allowAjaxReload'] = [
     'inputType' => 'checkbox',
     'eval'      => [
         'submitOnChange' => true,
-        'tl_class'       => 'clr w50 m12',
+        'tl_class'       => 'clr w50',
     ],
     'sql'       => "char(1) NOT NULL default ''",
 ];
@@ -43,7 +43,7 @@ $GLOBALS['TL_DCA']['tl_content']['fields']['ajaxReloadFormSubmit'] = [
     'label'     => &$GLOBALS['TL_LANG']['tl_content']['ajaxReloadFormSubmit'],
     'inputType' => 'checkbox',
     'eval'      => [
-        'tl_class' => 'w50 m12',
+        'tl_class' => 'clr w50',
     ],
     'sql'       => "char(1) NOT NULL default ''",
 ];

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -34,7 +34,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['allowAjaxReload'] = [
     'inputType' => 'checkbox',
     'eval'      => [
         'submitOnChange' => true,
-        'tl_class'       => 'clr w50 m12',
+        'tl_class'       => 'clr w50',
     ],
     'sql'       => "char(1) NOT NULL default ''",
 ];
@@ -43,7 +43,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['ajaxReloadFormSubmit'] = [
     'label'     => &$GLOBALS['TL_LANG']['tl_module']['ajaxReloadFormSubmit'],
     'inputType' => 'checkbox',
     'eval'      => [
-        'tl_class' => 'w50 m12',
+        'tl_class' => 'clr w50',
     ],
     'sql'       => "char(1) NOT NULL default ''",
 ];


### PR DESCRIPTION
The `m12` class only needs to be used on checkboxes, if they are floating in the same row as a text or select input field for example. When a single checkbox only floats by itself or together with another checkbox, the `m12` class is not necessary.

_Note:_ I think it's best though to add the functionality to its own fieldset, especially in `tl_content` and `tl_module`, since there is a subpalette present. If another extension appends to the same fieldset, the back end layout will get weird, when the subpalette is loaded. Alternatively, `w50` could be removed from the checkboxes as well, may be. (I did not include either change in this PR though.)