### PR TITLE
Modify palettes in onload_callback

### DIFF
--- a/src/EventListener/DataContainer/ModifyPalettesListener.php
+++ b/src/EventListener/DataContainer/ModifyPalettesListener.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of richardhj/contao-ajax_reload_element.
+ *
+ * Copyright (c) 2016-2018 Richard Henkenjohann
+ *
+ * @package   richardhj/contao-ajax_reload_element
+ * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright 2016-2018 Richard Henkenjohann
+ * @license   https://github.com/richardhj/contao-ajax_reload_element/blob/master/LICENSE LGPL-3.0
+ */
+
+namespace Richardhj\ContaoAjaxReloadElementBundle\EventListener\DataContainer;
+
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+use Contao\DataContainer;
+
+/**
+ * Class ModifyPalettesListener
+ */
+class ModifyPalettesListener
+{
+    public function __invoke(DataContainer $dc): void
+    {
+        foreach ($GLOBALS['TL_DCA'][$dc->table]['palettes'] as $name => $palette) {
+            if (!\is_string($palette)) {
+                continue;
+            }
+
+            if ('tl_content' === $dc->table && 'module' === $name) {
+                continue;
+            }
+
+            PaletteManipulator::create()
+                ->addField('allowAjaxReload', 'expert_legend', PaletteManipulator::POSITION_APPEND)
+                ->applyToPalette($name, $dc->table)
+            ;
+        }
+    }
+}

--- a/src/Resources/config/listeners.yml
+++ b/src/Resources/config/listeners.yml
@@ -3,3 +3,6 @@ services:
     arguments:
       - '@contao.image.picture_factory'
     public: true
+  
+  Richardhj\ContaoAjaxReloadElementBundle\EventListener\DataContanier\ModifyPalettesListener:
+    public: true

--- a/src/Resources/contao/dca/tl_article.php
+++ b/src/Resources/contao/dca/tl_article.php
@@ -11,11 +11,12 @@
  * @license   https://github.com/richardhj/contao-ajax_reload_element/blob/master/LICENSE LGPL-3.0
  */
 
+use Richardhj\ContaoAjaxReloadElementBundle\EventListener\DataContainer\ModifyPalettesListener;
 
 /**
- * Palettes
+ * Config
  */
-$GLOBALS['TL_DCA']['tl_article']['palettes']['default'] .= ',allowAjaxReload';
+$GLOBALS['TL_DCA']['tl_article']['config']['onload_callback'][] = [ModifyPalettesListener::class, '__invoke'];
 
 /**
  * Fields

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -11,19 +11,17 @@
  * @license   https://github.com/richardhj/contao-ajax_reload_element/blob/master/LICENSE LGPL-3.0
  */
 
+use Richardhj\ContaoAjaxReloadElementBundle\EventListener\DataContainer\ModifyPalettesListener;
+
+/**
+ * Config
+ */
+$GLOBALS['TL_DCA']['tl_content']['config']['onload_callback'][] = [ModifyPalettesListener::class, '__invoke'];
 
 /**
  * Palettes
  */
 $GLOBALS['TL_DCA']['tl_content']['palettes']['__selector__'][] = 'allowAjaxReload';
-foreach ($GLOBALS['TL_DCA']['tl_content']['palettes'] as $name => $palette) {
-    if (in_array($name, ['__selector__', 'module'])) {
-        continue;
-    }
-
-    $GLOBALS['TL_DCA']['tl_content']['palettes'][$name] .= ',allowAjaxReload';
-}
-
 $GLOBALS['TL_DCA']['tl_content']['subpalettes']['allowAjaxReload'] = 'ajaxReloadFormSubmit';
 
 /**

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -11,19 +11,17 @@
  * @license   https://github.com/richardhj/contao-ajax_reload_element/blob/master/LICENSE LGPL-3.0
  */
 
+use Richardhj\ContaoAjaxReloadElementBundle\EventListener\DataContainer\ModifyPalettesListener;
+
+/**
+ * Config
+ */
+$GLOBALS['TL_DCA']['tl_module']['config']['onload_callback'][] = [ModifyPalettesListener::class, '__invoke'];
 
 /**
  * Palettes
  */
 $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][] = 'allowAjaxReload';
-foreach ($GLOBALS['TL_DCA']['tl_module']['palettes'] as $name => $palette) {
-    if ('__selector__' === $name) {
-        continue;
-    }
-
-    $GLOBALS['TL_DCA']['tl_module']['palettes'][$name] .= ',allowAjaxReload';
-}
-
 $GLOBALS['TL_DCA']['tl_module']['subpalettes']['allowAjaxReload'] = 'ajaxReloadFormSubmit';
 
 /**


### PR DESCRIPTION
Currently certain module or content elements will not have the ajax reload checkbox from bundles that might get loaded _after_ the `RichardhjContaoAjaxReloadElementBundle`. This currently includes the `contao/calendar-bundle` for example - so there is no ajax reload checkbox in the modules of the Calendar Bundle.

This PR fixes this by modifying the palette in an `onload_callback` instead, ensuring that all palettes are already defined at that point (minus palettes that are themselves added in an `onload_callback`, but that's an edge case anyway and can be solved later on when increasing the minimum Contao version to 4.9 by using service tagging and a priority).