### PR TITLE
Fix error on index page

### DIFF
--- a/src/EventListener/AjaxReloadElementListener.php
+++ b/src/EventListener/AjaxReloadElementListener.php
@@ -104,9 +104,9 @@ class AjaxReloadElementListener
         list ($elementType, $elementId) = trimsplit('::', $paramElement);
 
         // Remove the get parameter from the url
-        $requestUrl = UrlBuilder::fromUrl(Environment::get('request'));
+        $requestUrl = UrlBuilder::fromUrl('/'.Environment::get('request'));
         $requestUrl->unsetQueryParameter('ajax_reload_element');
-        Environment::set('request', $requestUrl->getUrl());
+        Environment::set('request', ltrim($requestUrl->getUrl(), '/'));
 
         // Unset the get parameter (as it manipulates MetaModels filter url)
         Input::setGet('ajax_reload_element', null);


### PR DESCRIPTION
There is an error if you try to load an element or module on the start page (`index`). In this case `Environment::get('request')` will return an empty string or something like

```
?page_n2=2
```

in case of a newslist pagination for example. Running that through the `ContaoCommunityAlliance\UrlBuilder\UrlBuilder` will then however give you the following URL:

```
page_n2=2
```

This is of course wrong - and this wrong request URL will then be set in the `Environment` - which will break any URLs generated by Contao. To work around this bug, this PR simply prepends the `request` URL with a slash - and then removes it again, since the `Environment` class assumes it to be without the leading slash (contrary to Symfony's `Request`).

See also https://github.com/contao-community-alliance/url-builder/issues/3